### PR TITLE
Case-insensitive commands / shortcuts

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -73,7 +73,7 @@ bot.on('message', msg => {
     if (!msg.content.startsWith(config.prefix)) return;
 
     var split = msg.content.split(' ');
-    var base = split[0].substr(config.prefix.length);
+    var base = split[0].substr(config.prefix.length).toLowerCase();
     var args = split.slice(1);
 
     var command = commands.get(base);
@@ -95,7 +95,7 @@ bot.on('message', msg => {
                         .then(m => m.delete(5000));
                 }
             } else {
-                base = sc.command.split(' ')[0];
+                base = sc.command.split(' ')[0].toLowerCase();
                 args = sc.command.split(' ').splice(1).concat(args);
 
                 command = commands.get(base);

--- a/src/commands/Utility/shortcuts.js
+++ b/src/commands/Utility/shortcuts.js
@@ -13,7 +13,7 @@ exports.run = (bot, msg, args) => {
         if (args.length < 3) {
             throw `Usage: \`${bot.config.prefix}shortcut add <id> <command>\``;
         }
-        let id = args[1];
+        let id = args[1].toLowerCase();
         var command = args.slice(2).join(' ');
         bot.db.get(`shortcuts.${id}`).then(sc => {
             if (sc) {


### PR DESCRIPTION
Makes all commands case-insensitive, makes shortcut retrieval and add all case-insensitive, does NOT make removal case-insensitive incase there are old capital letter commands.

**Warning:** Does make shortcuts all lower-case, so previous shortcuts that are capital letters will need to be recreated.