### PR TITLE
Fixed small bug in serverinfo when ran in DMs

### DIFF
--- a/src/commands/Info/serverinfo.js
+++ b/src/commands/Info/serverinfo.js
@@ -6,15 +6,15 @@ dateFormat(now, 'dddd, mmmm dS, yyyy, h:MM:ss TT');
 
 exports.run = function (bot, msg) {
     
+    if (!msg.guild) {
+        throw 'This can only be used in a guild!';
+    }
+    
     const millis = new Date().getTime() - msg.guild.createdAt.getTime();
     const days = millis/1000/60/60/24;
     
     const verificationLevels = ['None', 'Low', 'Medium', 'Insane'];
 
-    
-    if (!msg.guild) {
-        throw 'This can only be used in a guild!';
-    }
 
     let embed = bot.utils.embed(
         `${msg.guild.name}`,


### PR DESCRIPTION
When you did the serverinfo command in a DM, it would print a different error message to what was expected. Although this isn't a huge issue as it doesn't interfere with the command itself, I felt it didn't look clean enough so I just had to move the if statement up a few lines to fix it.